### PR TITLE
python dependencies changed

### DIFF
--- a/ansible/roles/spark_master/tasks/main.yml
+++ b/ansible/roles/spark_master/tasks/main.yml
@@ -38,7 +38,7 @@
           state: present
           name:
             - "hail=={{ hail_version }}"
-            - pyspark
+            - "pyspark=={{ spark_version }}"
             - jupyterlab==2.2.9
             - pyopenssl
           virtualenv: "{{ venv_dir }}"

--- a/ansible/roles/spark_master/tasks/main.yml
+++ b/ansible/roles/spark_master/tasks/main.yml
@@ -49,7 +49,7 @@
   become_user: "{{ spark_user }}"
   pip:
           state: present
-          name: "{{ extra_python_modules }}"
+          name: "{{ master_extra_python_modules }}"
           virtualenv: "{{ venv_dir }}"
           virtualenv_command: /usr/bin/python3 -m venv
 

--- a/ansible/roles/spark_workers/tasks/main.yml
+++ b/ansible/roles/spark_workers/tasks/main.yml
@@ -29,7 +29,7 @@
   become_user: "{{ spark_user }}"
   pip:
           state: present
-          name: "{{ extra_python_modules }}"
+          name: "{{ worker_extra_python_modules }}"
           virtualenv: "{{ venv_dir }}"
           virtualenv_command: /usr/bin/python3 -m venv
 

--- a/ansible/roles/spark_workers/tasks/main.yml
+++ b/ansible/roles/spark_workers/tasks/main.yml
@@ -20,7 +20,16 @@
   become_user: "{{ spark_user }}"
   pip:
           state: present
-          name: pyspark~=2.4
+          name: "pyspark=={{ spark_version }}"
+          virtualenv: "{{ venv_dir }}"
+          virtualenv_command: /usr/bin/python3 -m venv
+
+- name: Install extra python modules in venv
+  become: yes
+  become_user: "{{ spark_user }}"
+  pip:
+          state: present
+          name: "{{ extra_python_modules }}"
           virtualenv: "{{ venv_dir }}"
           virtualenv_command: /usr/bin/python3 -m venv
 

--- a/vars.yml
+++ b/vars.yml
@@ -30,7 +30,9 @@ hail_version: 0.2.105
 extra_pkgs:
 
 ## Additional pip python modules to install on the cluster
-extra_python_modules:
+master_extra_python_modules:
+
+worker_extra_python_modules:
   - numpy
 
 ###############################################################################

--- a/vars.yml
+++ b/vars.yml
@@ -31,6 +31,7 @@ extra_pkgs:
 
 ## Additional pip python modules to install on the cluster
 extra_python_modules:
+  - numpy
 
 ###############################################################################
 ## Default hadoop configuration. Full configuration options at bottom of 


### PR DESCRIPTION
* pyspark version fixed to spark version (not 2.4.* anymore)
* extra python libraries can be set for master and worker nodes separately
* numpy is installed on worker nodes by default